### PR TITLE
Feat/#41 대댓글 기능 구현

### DIFF
--- a/nginx/conf.d/default.conf
+++ b/nginx/conf.d/default.conf
@@ -1,13 +1,13 @@
-# HTTP to HTTPS redirect
+# HTTP server - SSL로 리다이렉트
 server {
     listen 80;
     server_name devseed.store www.devseed.store;
-    
+
     # Certbot challenge
     location /.well-known/acme-challenge/ {
         root /var/www/certbot;
     }
-    
+
     # Redirect all HTTP traffic to HTTPS
     location / {
         return 301 https://$server_name$request_uri;
@@ -22,19 +22,19 @@ server {
     # SSL Configuration
     ssl_certificate /etc/letsencrypt/live/devseed.store/fullchain.pem;
     ssl_certificate_key /etc/letsencrypt/live/devseed.store/privkey.pem;
-    
+
     # SSL Security
     ssl_protocols TLSv1.2 TLSv1.3;
     ssl_ciphers ECDHE-RSA-AES256-GCM-SHA512:DHE-RSA-AES256-GCM-SHA512:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES256-GCM-SHA384;
     ssl_prefer_server_ciphers off;
     ssl_session_cache shared:SSL:10m;
     ssl_session_timeout 10m;
-    
+
     # HSTS
     add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
 
-    # API routes
-    location /api/ {
+    # 모든 요청을 Spring Boot로 프록시
+    location / {
         proxy_pass http://spring-app:8080;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
@@ -42,60 +42,23 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_set_header X-Forwarded-Host $host;
         proxy_set_header X-Forwarded-Port $server_port;
-        
+
+        # WebSocket 지원 (필요한 경우)
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+
         # Timeout settings
         proxy_connect_timeout 60s;
         proxy_send_timeout 60s;
         proxy_read_timeout 60s;
-        
+
         # Buffer settings
         proxy_buffer_size 4k;
         proxy_buffers 8 4k;
         proxy_busy_buffers_size 8k;
-    }
 
-    # OAuth2 routes
-    location /oauth2/ {
-        proxy_pass http://spring-app:8080;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_set_header X-Forwarded-Host $host;
-        proxy_set_header X-Forwarded-Port $server_port;
-    }
-
-    # Login OAuth2 callback
-    location /login/oauth2/ {
-        proxy_pass http://spring-app:8080;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_set_header X-Forwarded-Host $host;
-        proxy_set_header X-Forwarded-Port $server_port;
-    }
-
-    # Health check
-    location /healthcheck {
-        proxy_pass http://spring-app:8080;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-    }
-
-    # Frontend routes (if serving frontend from same domain)
-    location / {
-        # Replace with your frontend container or static files
-        try_files $uri $uri/ /index.html;
-        root /var/www/html;
-        index index.html index.htm;
-    }
-
-    # Security headers for API responses
-    location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg)$ {
-        expires 1y;
-        add_header Cache-Control "public, immutable";
+        # 큰 요청 본문 허용 (파일 업로드 등)
+        client_max_body_size 10M;
     }
 }

--- a/src/main/java/com/seed/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/seed/domain/comment/controller/CommentController.java
@@ -2,12 +2,16 @@ package com.seed.domain.comment.controller;
 
 import com.seed.domain.comment.dto.request.CommentRequest;
 import com.seed.domain.comment.dto.response.CommentResponse;
-import com.seed.domain.comment.repository.CommentRepository;
+import com.seed.domain.comment.dto.response.SwaggerCommentApiResponse;
 import com.seed.domain.comment.service.CommentCommandService;
 import com.seed.domain.comment.service.CommentQueryService;
 import com.seed.domain.user.entity.User;
-import com.seed.global.paging.CursorPage;
 import com.seed.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -17,27 +21,51 @@ import java.util.List;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/memoirs/{memoirId}/comments")
+@Tag(name = "댓글 API")
 public class CommentController {
 
     private final CommentCommandService commentCommandService;
     private final CommentQueryService commentQueryService;
 
-    @PostMapping
+    @PostMapping("")
+    @Operation(
+            summary = "댓글 작성 API",
+            description = "댓글을 작성하는 API입니다. 댓글을 작성할 회고의 ID와 내용을 입력해주세요. " +
+                    "대댓글의 경우, 대댓글을 달 댓글의 ID를 담아서 넘겨주세요."
+    )
     public ApiResponse<?> addComment(
             @PathVariable Long memoirId,
             @AuthenticationPrincipal User user,
-            @RequestBody CommentRequest.CreateRequestDTO requestDTO
+            @RequestBody @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    content = @Content(schema = @Schema(implementation = CommentRequest.CreateRequestDTO.class))
+            ) CommentRequest.CreateRequestDTO requestDTO
     ) {
         commentCommandService.createComment(user.getId(), memoirId, requestDTO);
         return ApiResponse.success("댓글이 생성되었습니다.");
     }
 
-    @GetMapping
-    public ApiResponse<CursorPage<List<CommentResponse.InfoDTO>>> getComments(
-            @PathVariable Long memoirId,
-            @RequestParam(name = "cursor", required = false) Long cursor,
-            @RequestParam(name = "size", defaultValue = "10", required = false) int size
+//    @GetMapping
+//    public ApiResponse<CursorPage<List<CommentResponse.InfoDTO>>> getComments(
+//            @PathVariable Long memoirId,
+//            @RequestParam(name = "cursor", required = false) Long cursor,
+//            @RequestParam(name = "size", defaultValue = "10", required = false) int size
+//    ) {
+//        return ApiResponse.success(commentQueryService.getComments(memoirId, cursor, size));
+//    }
+
+    @GetMapping("")
+    @Operation(
+            summary = "댓글 목록 조회 API",
+            description = "특정 회고의 달린 모든 댓글 목록을 조회합니다. 최신 댓글이 항상 마지막에 위치합니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    content = @Content(schema = @Schema(implementation = SwaggerCommentApiResponse.class))
+            )
+    })
+    public ApiResponse<List<CommentResponse.InfoDTO>> getComments(
+            @PathVariable Long memoirId
     ) {
-        return ApiResponse.success(commentQueryService.getComments(memoirId, cursor, size));
+        return ApiResponse.success(commentQueryService.getComments(memoirId));
     }
 }

--- a/src/main/java/com/seed/domain/comment/converter/CommentConverter.java
+++ b/src/main/java/com/seed/domain/comment/converter/CommentConverter.java
@@ -1,5 +1,6 @@
 package com.seed.domain.comment.converter;
 
+import com.seed.domain.comment.dto.request.CommentRequest;
 import com.seed.domain.comment.dto.response.CommentResponse;
 import com.seed.domain.comment.entity.Comment;
 import com.seed.domain.memoir.entity.Memoir;
@@ -7,9 +8,10 @@ import com.seed.domain.user.entity.User;
 
 public class CommentConverter {
 
-    public static Comment toComment(String content, Long userId, Long memoirId) {
+    public static Comment toComment(CommentRequest.CreateRequestDTO requestDTO, Long userId, Long memoirId) {
         return Comment.builder()
-                .content(content)
+                .parentId(requestDTO.getParentCommentId())
+                .content(requestDTO.getContent())
                 .user(User.ofId(userId))
                 .memoir(Memoir.ofId(memoirId))
                 .build();

--- a/src/main/java/com/seed/domain/comment/dto/request/CommentRequest.java
+++ b/src/main/java/com/seed/domain/comment/dto/request/CommentRequest.java
@@ -6,6 +6,7 @@ public class CommentRequest {
 
     @Getter
     public static class CreateRequestDTO {
+        private Long parentCommentId;
         private String content;
     }
 }

--- a/src/main/java/com/seed/domain/comment/dto/request/CommentRequest.java
+++ b/src/main/java/com/seed/domain/comment/dto/request/CommentRequest.java
@@ -1,10 +1,18 @@
 package com.seed.domain.comment.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 public class CommentRequest {
 
     @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    @Schema
     public static class CreateRequestDTO {
         private Long parentCommentId;
         private String content;

--- a/src/main/java/com/seed/domain/comment/dto/response/CommentResponse.java
+++ b/src/main/java/com/seed/domain/comment/dto/response/CommentResponse.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 public class CommentResponse {
 
@@ -19,5 +20,10 @@ public class CommentResponse {
         private String author;
         private String profileImageUrl;
         private LocalDateTime createdAt;
+        private List<CommentResponse.InfoDTO> children;
+
+        public void setChildren(List<CommentResponse.InfoDTO> children) {
+            this.children = children;
+        }
     }
 }

--- a/src/main/java/com/seed/domain/comment/dto/response/SwaggerCommentApiResponse.java
+++ b/src/main/java/com/seed/domain/comment/dto/response/SwaggerCommentApiResponse.java
@@ -1,0 +1,11 @@
+package com.seed.domain.comment.dto.response;
+
+import com.seed.global.response.ApiResponse;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class SwaggerCommentApiResponse {
+    ApiResponse<List<CommentResponse.InfoDTO>> response;
+}

--- a/src/main/java/com/seed/domain/comment/repository/CommentQueryRepositoryImpl.java
+++ b/src/main/java/com/seed/domain/comment/repository/CommentQueryRepositoryImpl.java
@@ -30,7 +30,7 @@ public class CommentQueryRepositoryImpl implements CommentQueryRepository {
         query = queryFactory.selectFrom(comment)
                 .join(comment.user, user).fetchJoin()
                 .where(comment.memoir.id.eq(memoirId))
-                .orderBy(comment.id.asc())
+                .orderBy(comment.id.desc())
                 .limit(size + 1);
 
         if(cursor != null) {

--- a/src/main/java/com/seed/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/seed/domain/comment/repository/CommentRepository.java
@@ -2,6 +2,13 @@ package com.seed.domain.comment.repository;
 
 import com.seed.domain.comment.entity.Comment;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface CommentRepository extends JpaRepository<Comment, Long>, CommentQueryRepository {
+
+    @Query("select c from Comment c join fetch c.user u where c.memoir.id = :memoirId")
+    List<Comment> findAllByMemoirIdOrderById(@Param("memoirId") Long memoirId);
 }

--- a/src/main/java/com/seed/domain/comment/service/CommentCommandService.java
+++ b/src/main/java/com/seed/domain/comment/service/CommentCommandService.java
@@ -23,17 +23,21 @@ public class CommentCommandService {
     private final MemoirRepository memoirRepository;
 
     public void createComment(Long userId, Long memoirId, CommentRequest.CreateRequestDTO request) {
-        validateUserAndMemoir(userId, memoirId);
-        commentRepository.save(CommentConverter.toComment(request.getContent(), userId, memoirId));
+        validateUserAndMemoirAndComment(userId, memoirId, request.getParentCommentId());
+        commentRepository.save(CommentConverter.toComment(request, userId, memoirId));
     }
 
-    private void validateUserAndMemoir(Long userId, Long memoirId) {
+    private void validateUserAndMemoirAndComment(Long userId, Long memoirId, Long commentId) {
         if(!userRepository.existsById(userId)) {
             throw new BusinessException(ErrorCode.USER_NOT_FOUND, "해당하는 유저가 존재하지 않습니다.");
         }
 
         if(!memoirRepository.existsById(memoirId)) {
             throw new BusinessException(ErrorCode.NOT_FOUND, "해당하는 회고 글이 존재하지 않습니다.");
+        }
+
+        if(!commentRepository.existsById(commentId)) {
+            throw new BusinessException(ErrorCode.NOT_FOUND, "대댓글을 작성할 댓글이 존재하지 않습니다.");
         }
     }
 }

--- a/src/main/java/com/seed/domain/comment/service/CommentCommandService.java
+++ b/src/main/java/com/seed/domain/comment/service/CommentCommandService.java
@@ -27,7 +27,7 @@ public class CommentCommandService {
         commentRepository.save(CommentConverter.toComment(request, userId, memoirId));
     }
 
-    private void validateUserAndMemoirAndComment(Long userId, Long memoirId, Long commentId) {
+    private void validateUserAndMemoirAndComment(Long userId, Long memoirId, Long parentCommentId) {
         if(!userRepository.existsById(userId)) {
             throw new BusinessException(ErrorCode.USER_NOT_FOUND, "해당하는 유저가 존재하지 않습니다.");
         }
@@ -36,8 +36,10 @@ public class CommentCommandService {
             throw new BusinessException(ErrorCode.NOT_FOUND, "해당하는 회고 글이 존재하지 않습니다.");
         }
 
-        if(!commentRepository.existsById(commentId)) {
-            throw new BusinessException(ErrorCode.NOT_FOUND, "대댓글을 작성할 댓글이 존재하지 않습니다.");
+        if(parentCommentId != null) {
+            if(!commentRepository.existsById(parentCommentId)) {
+                throw new BusinessException(ErrorCode.NOT_FOUND, "대댓글을 작성할 댓글이 존재하지 않습니다.");
+            }
         }
     }
 }

--- a/src/main/java/com/seed/domain/comment/service/CommentQueryService.java
+++ b/src/main/java/com/seed/domain/comment/service/CommentQueryService.java
@@ -1,6 +1,8 @@
 package com.seed.domain.comment.service;
 
+import com.seed.domain.comment.converter.CommentConverter;
 import com.seed.domain.comment.dto.response.CommentResponse;
+import com.seed.domain.comment.entity.Comment;
 import com.seed.domain.comment.repository.CommentRepository;
 import com.seed.global.paging.CursorPage;
 import lombok.RequiredArgsConstructor;
@@ -8,6 +10,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Service
@@ -21,4 +24,29 @@ public class CommentQueryService {
     public CursorPage<List<CommentResponse.InfoDTO>> getComments(Long memoirId, Long nextCursor, int size) {
         return commentRepository.getComments(memoirId, nextCursor, size);
     }
+
+    public List<CommentResponse.InfoDTO> getComments(Long memoirId) {
+        List<Comment> comments = commentRepository.findAllByMemoirIdOrderById(memoirId);
+
+        List<CommentResponse.InfoDTO> parentComments = new ArrayList<>();
+
+        comments.stream()
+                .filter(comment -> comment.getParentId() == null)
+                .forEach(comment -> {
+                    CommentResponse.InfoDTO infoDTO = CommentConverter.toInfoDTO(comment);
+                    parentComments.add(infoDTO);
+                });
+
+        for (CommentResponse.InfoDTO parentComment : parentComments) {
+            List<CommentResponse.InfoDTO> childComments = comments.stream()
+                    .filter(comment -> comment.getParentId() != null && comment.getParentId().equals(parentComment.getId()))
+                    .map(CommentConverter::toInfoDTO)
+                    .toList();
+
+            parentComment.setChildren(childComments);
+        }
+
+        return parentComments;
+    }
+
 }

--- a/src/main/java/com/seed/global/oauth2/handler/OAuth2AuthSuccessHandler.java
+++ b/src/main/java/com/seed/global/oauth2/handler/OAuth2AuthSuccessHandler.java
@@ -60,6 +60,7 @@ public class OAuth2AuthSuccessHandler extends SimpleUrlAuthenticationSuccessHand
 
         // JWT 토큰 생성
         String refreshToken = jwtUtil.generateRefreshToken(socialId);
+        String accessToken = jwtUtil.generateAccessToken(socialId);
 
         log.info("Refresh token: {}", refreshToken);
 
@@ -73,7 +74,7 @@ public class OAuth2AuthSuccessHandler extends SimpleUrlAuthenticationSuccessHand
         log.info("Cookie created : {}", createCookie("refreshToken", refreshToken, 60 * 60 * 24 * 7));
 
         // 프론트엔드 페이지로 리다이렉트
-        redirectURL = UriComponentsBuilder.fromUriString(frontendUrl)
+        redirectURL = UriComponentsBuilder.fromUriString(frontendUrl + "?token=" + accessToken)
                 .build()
                 .encode(StandardCharsets.UTF_8)
                 .toUriString();

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -15,7 +15,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
     show-sql: true
     database-platform: org.hibernate.dialect.MySQLDialect
     defer-datasource-initialization: true

--- a/src/test/java/com/seed/domain/mapping/like/service/LikeQueryServiceTest.java
+++ b/src/test/java/com/seed/domain/mapping/like/service/LikeQueryServiceTest.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.Rollback;
 
 import java.util.List;
 


### PR DESCRIPTION
## #️⃣ Issue Number

<!--- ex) #이슈번호, #이슈번호 -->

## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

### 1. 대댓글 작성 API 구현
- 기존 댓글에 대댓글을 작성하는 API를 구현하였습니다. request body 에 대댓글을 작성할 댓글의 ID를 받아 처리합니다.

### 2. 전체 댓글 목록 조회 API 구현
- 특정 회고에 달린 모든 댓글 목록을 조회하는 API를 구현하였습니다. 가장 최신 댓글이 항상 맨 아래에 위치하도록 ID 오름차순으로 구현하였습니다. 대댓글도 동일하게 적용됩니다.

### 추가 
로그인 성공 후 accessToken 이 쿼리 파라미터에 담겨 오도록 수정하였습니다.

## 🛠️ PR 유형

어떤 변경 사항이 있나요? (추가하거나 제거하여 사용하세요)

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 💬 공유사항

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
