### PR TITLE
Feat/#58 기업명 검색시 자동완성 api

### DIFF
--- a/src/main/java/com/seed/domain/company/controller/CompanyController.java
+++ b/src/main/java/com/seed/domain/company/controller/CompanyController.java
@@ -1,0 +1,26 @@
+package com.seed.domain.company.controller;
+
+import com.seed.domain.company.dto.response.CompanyResponse;
+import com.seed.domain.company.service.CompanyService;
+import com.seed.global.constant.AppConstants;
+import com.seed.global.response.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/company")
+public class CompanyController {
+    private final CompanyService companyService;
+
+    @GetMapping("/search")
+    public ApiResponse<List<CompanyResponse>> searchCompany(@RequestParam String keyword) {
+        List<CompanyResponse> listCompanyRes = companyService.searchCompany(keyword, AppConstants.COMPANY_SUGGEST_DEFAULT_LIMIT);
+        return ApiResponse.success(listCompanyRes);
+    }
+}

--- a/src/main/java/com/seed/domain/company/dto/response/CompanyResponse.java
+++ b/src/main/java/com/seed/domain/company/dto/response/CompanyResponse.java
@@ -1,0 +1,24 @@
+package com.seed.domain.company.dto.response;
+
+import com.seed.domain.company.entity.Company;
+import lombok.*;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class CompanyResponse {
+    private Long id;
+    private String region;
+    private String name;
+    private String ceoName;
+
+    public static CompanyResponse fromEntity(Company company) {
+        return CompanyResponse.builder()
+                .id(company.getId())
+                .region(company.getRegion())
+                .name(company.getName())
+                .ceoName(company.getCeoName())
+                .build();
+    }
+}

--- a/src/main/java/com/seed/domain/company/entity/Company.java
+++ b/src/main/java/com/seed/domain/company/entity/Company.java
@@ -1,12 +1,15 @@
-package com.seed.domain.company;
+package com.seed.domain.company.entity;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
 import lombok.*;
 
 @Entity
+@Table(
+    name = "company",
+    indexes = {
+        @Index(name = "idx_company_name", columnList = "name"),
+    }
+)
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)

--- a/src/main/java/com/seed/domain/company/repository/CompanyRepository.java
+++ b/src/main/java/com/seed/domain/company/repository/CompanyRepository.java
@@ -1,0 +1,24 @@
+package com.seed.domain.company.repository;
+
+import com.seed.domain.company.entity.Company;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface CompanyRepository extends JpaRepository<Company, Long> {
+
+    @Query("""
+        select c
+        from Company c
+        where lower(c.name) like lower(concat(:keyword, '%'))
+           or lower(c.name) like lower(concat('%', :keyword, '%'))
+        order by
+          case when lower(c.name) like lower(concat(:keyword, '%')) then 0 else 1 end,
+          c.name asc
+        """)
+    List<Company> searchCompanyByName(@Param("keyword") String keyword, Pageable pageable);
+
+}

--- a/src/main/java/com/seed/domain/company/service/CompanyService.java
+++ b/src/main/java/com/seed/domain/company/service/CompanyService.java
@@ -1,0 +1,9 @@
+package com.seed.domain.company.service;
+
+import com.seed.domain.company.dto.response.CompanyResponse;
+
+import java.util.List;
+
+public interface CompanyService {
+    List<CompanyResponse> searchCompany(String keyword, int limit);
+}

--- a/src/main/java/com/seed/domain/company/service/impl/CompanyServiceImpl.java
+++ b/src/main/java/com/seed/domain/company/service/impl/CompanyServiceImpl.java
@@ -1,0 +1,33 @@
+package com.seed.domain.company.service.impl;
+
+import com.seed.domain.company.dto.response.CompanyResponse;
+import com.seed.domain.company.repository.CompanyRepository;
+import com.seed.domain.company.service.CompanyService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class CompanyServiceImpl implements CompanyService {
+
+    private final CompanyRepository companyRepository;
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<CompanyResponse> searchCompany(String keyword, int limit) {
+        if (keyword == null || keyword.trim().length() < 2) {
+            return List.of();
+        }
+
+        Pageable pageable = PageRequest.of(0, limit);
+        return companyRepository.searchCompanyByName(keyword.trim(), pageable)
+                .stream()
+                .map(CompanyResponse::fromEntity)
+                .toList();
+    }
+}

--- a/src/main/java/com/seed/domain/schedule/entity/Schedule.java
+++ b/src/main/java/com/seed/domain/schedule/entity/Schedule.java
@@ -1,6 +1,6 @@
 package com.seed.domain.schedule.entity;
 
-import com.seed.domain.company.Company;
+import com.seed.domain.company.entity.Company;
 import com.seed.domain.memoir.entity.Memoir;
 import com.seed.domain.schedule.dto.request.ScheduleRequest;
 import com.seed.domain.schedule.enums.InterviewStep;

--- a/src/main/java/com/seed/global/constant/AppConstants.java
+++ b/src/main/java/com/seed/global/constant/AppConstants.java
@@ -1,0 +1,8 @@
+package com.seed.global.constant;
+
+public final class AppConstants {
+    private AppConstants() {}
+
+    // Company
+    public static final int COMPANY_SUGGEST_DEFAULT_LIMIT = 10;
+}


### PR DESCRIPTION
## #️⃣ Issue Number

Closes #58 

## 📝 요약(Summary)

일정 등록 혹은 면접 회고 등록에서 기업명을 입력할 때 사용되는 기업명 자동완성 API 기능입니다.
최대 10개까지 보여주며, 2글자 이상 입력 했을 때 자동완성이 시작됩니다.

## 🛠️ PR 유형

어떤 변경 사항이 있나요? (추가하거나 제거하여 사용하세요)

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 💬 공유사항

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
