### PR TITLE
Feat:#88 refreshToken을 URL에 추가&회원 프로필 조회 API 구현

### DIFF
--- a/src/main/java/com/seed/domain/user/controller/UserInfoController.java
+++ b/src/main/java/com/seed/domain/user/controller/UserInfoController.java
@@ -1,8 +1,10 @@
 package com.seed.domain.user.controller;
 
 import com.seed.domain.user.dto.request.UserInfoUpdateRequest;
+import com.seed.domain.user.dto.response.UserInfoResponse;
 import com.seed.domain.user.entity.User;
 import com.seed.domain.user.service.UserCommandService;
+import com.seed.domain.user.service.UserQueryService;
 import com.seed.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -25,6 +27,16 @@ import org.springframework.web.multipart.MultipartFile;
 public class UserInfoController {
 
     private final UserCommandService userCommandService;
+    private final UserQueryService userQueryService;
+
+    @Operation(
+            summary = "회원 프로필 조회 API",
+            description = "현재 로그인한 회원의 프로필을 조회합니다."
+    )
+    @GetMapping("/profile")
+    public ApiResponse<UserInfoResponse> getProfile(@AuthenticationPrincipal User user) {
+        return ApiResponse.success(userQueryService.getUserInfo(user.getId()));
+    }
 
     @Operation(
             summary = "프로필 정보 수정 API",
@@ -60,7 +72,6 @@ public class UserInfoController {
             @Parameter(description = "프로필 이미지 파일")
             @RequestPart(value = "profileImage", required = false) MultipartFile profileImage
     ) {
-
         log.info("Content-Type: {}", httpRequest.getContentType());
         log.info("Request: {}", request);
         log.info("ProfileImage: {}", profileImage != null ? profileImage.getOriginalFilename() : "null");

--- a/src/main/java/com/seed/domain/user/converter/UserConverter.java
+++ b/src/main/java/com/seed/domain/user/converter/UserConverter.java
@@ -1,6 +1,7 @@
 package com.seed.domain.user.converter;
 
 import com.seed.domain.user.dto.request.CreateUserSearchHistRequest;
+import com.seed.domain.user.dto.response.UserInfoResponse;
 import com.seed.domain.user.dto.response.UserSearchHistResponse;
 import com.seed.domain.user.entity.User;
 import com.seed.domain.user.entity.UserSearchHist;
@@ -18,6 +19,13 @@ public class UserConverter {
         return UserSearchHist.builder()
                 .user(User.ofId(createUserSearchHistRequest.getUserId()))
                 .content(createUserSearchHistRequest.getContent())
+                .build();
+    }
+
+    public static UserInfoResponse toUserInfoResponse(User user) {
+        return UserInfoResponse.builder()
+                .username(user.getName())
+                .profileImageUrl(user.getImageUrl())
                 .build();
     }
 }

--- a/src/main/java/com/seed/domain/user/dto/response/UserInfoResponse.java
+++ b/src/main/java/com/seed/domain/user/dto/response/UserInfoResponse.java
@@ -1,0 +1,15 @@
+package com.seed.domain.user.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class UserInfoResponse {
+    private String username;
+    private String profileImageUrl;
+}

--- a/src/main/java/com/seed/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/seed/domain/user/repository/UserRepository.java
@@ -11,4 +11,5 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     @Query("select u from User u where u.socialId = :socialId and u.isUse = true")
     Optional<User> findBySocialId(@Param("socialId") String socialId);
+
 }

--- a/src/main/java/com/seed/domain/user/service/UserQueryService.java
+++ b/src/main/java/com/seed/domain/user/service/UserQueryService.java
@@ -1,0 +1,28 @@
+package com.seed.domain.user.service;
+
+import com.seed.domain.user.converter.UserConverter;
+import com.seed.domain.user.dto.response.UserInfoResponse;
+import com.seed.domain.user.entity.User;
+import com.seed.domain.user.repository.UserRepository;
+import com.seed.global.exception.BusinessException;
+import com.seed.global.response.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+@Slf4j
+public class UserQueryService {
+
+    private final UserRepository userRepository;
+
+    public UserInfoResponse getUserInfo(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        return UserConverter.toUserInfoResponse(user);
+    }
+}

--- a/src/main/java/com/seed/global/oauth2/handler/OAuth2AuthSuccessHandler.java
+++ b/src/main/java/com/seed/global/oauth2/handler/OAuth2AuthSuccessHandler.java
@@ -74,7 +74,7 @@ public class OAuth2AuthSuccessHandler extends SimpleUrlAuthenticationSuccessHand
         log.info("Cookie created : {}", createCookie("refreshToken", refreshToken, 60 * 60 * 24 * 7));
 
         // 프론트엔드 페이지로 리다이렉트
-        redirectURL = UriComponentsBuilder.fromUriString(frontendUrl + "?token=" + accessToken)
+        redirectURL = UriComponentsBuilder.fromUriString(frontendUrl + "?token=" + accessToken + "&refresh=" + refreshToken)
                 .build()
                 .encode(StandardCharsets.UTF_8)
                 .toUriString();


### PR DESCRIPTION
## #️⃣ Issue Number

<!--- ex) #이슈번호, #이슈번호 -->

## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

### 1. 로그인 성공 시 URL에 refreshToken 값 추가
- 기존에는 accessToken만 넘겼으나, refreshToken도 추가하였습니다.

### 2. 회원 프로필 조회 API구현
- 회원의 닉네임과 프로필 이미지URL을 조회할 수 있는 API를 구현하였습니다.

## 🛠️ PR 유형

어떤 변경 사항이 있나요? (추가하거나 제거하여 사용하세요)

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 💬 공유사항

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a profile retrieval API to fetch a user’s username and profile image.
- Improvements
  - Login redirect now returns both access and refresh tokens for smoother, longer-lived sessions.
- Documentation
  - Added public API documentation for the new profile endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->